### PR TITLE
github: workflows: add base workflows

### DIFF
--- a/.github/workflows/docker-add-version-and-latest-tags.yaml
+++ b/.github/workflows/docker-add-version-and-latest-tags.yaml
@@ -1,0 +1,42 @@
+name: Add version and latest tags to docker image
+
+on:
+  workflow_call:
+    inputs:
+      images:
+        description: "Stringified JSON object listing that contains image name and tag"
+        required: true
+        type: string
+        default: >-
+          {
+            "include": [
+              {
+                "image": "docker-registry/user/myapp",
+                "image_tag": "test123"
+              }
+            ]
+          }
+    secrets:
+      doctl_token:
+        description: "DigitalOcean docker registry access token"
+        required: true
+jobs:
+  dockertag:
+    name: Make new docker tags
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{fromJson(inputs.images)}}
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.doctl_token }}
+      - name: Login to the DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 600
+      - name: Make ${{ matrix.image }} docker tag
+        run: |
+          docker pull ${{ matrix.image }}:${{ matrix.image_tag }}
+          for tag in "latest" "${{ github.event.release.tag_name }}"; do
+            docker tag ${{ matrix.image }}:${{ matrix.image_tag }} ${{ matrix.image }}:${tag}
+            docker push ${{ matrix.image }}:${tag}
+          done

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1,0 +1,70 @@
+name: Build and push docker images
+
+on:
+  workflow_call:
+    inputs:
+      services:
+        description: "Stringified JSON object listing docker build parameters"
+        required: true
+        type: string
+        default: >-
+          {
+            "include": [
+              {
+                "context": ".",
+                "tags": "registry.org/user:v1.0.0",
+                "target": "",
+                "file": "Dockerfile",
+                "build-args": ""
+              }
+            ]
+          }
+    secrets:
+      build_secrets:
+        description: "Docker build secrets"
+        required: false
+      doctl_token:
+        description: "DigitalOcean docker registry access token"
+        required: true
+jobs:
+  dockerbuild:
+    name: Build and push docker images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(inputs.services)}}
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.doctl_token }}
+      - name: Login to the DigitalOcean Container Registry
+        run: doctl registry login --expiry-seconds 600
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "true"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ matrix.tags }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.tags }}-
+      - name: Build the ${{ matrix.tags }}
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          target: ${{ matrix.target }}
+          tags: ${{ matrix.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          file: ${{ matrix.file }}
+          build-args: ${{ matrix.build-args }}
+          secrets: ${{ secrets.build_secrets }}
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/dockerlint.yaml
+++ b/.github/workflows/dockerlint.yaml
@@ -1,0 +1,24 @@
+name: Hadolint dockerfile linter
+
+on:
+  workflow_call:
+    inputs:
+      dockerfiles:
+        description: "Stringified JSON object listing target dockerfiles"
+        required: false
+        type: string
+        default: >-
+          ["./Dockerfile"]
+jobs:
+  hadolint:
+    name: Lint Dockerfiles
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: ${{fromJson(inputs.dockerfiles)}}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Docker lint ${{ matrix.dockerfile }}
+        run: docker run --rm -i "hadolint/hadolint:v2.2.0" < "${{ matrix.dockerfile }}"

--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -1,0 +1,22 @@
+name: Git linter
+
+on:
+  workflow_call:
+
+jobs:
+  gitlint:
+    name: Lint commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v1
+        with:
+          submodules: "true"
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install gitlint
+        run: pip install gitlint
+      - name: Run gitlint
+        run: gitlint --config code-quality/git/gitlint --commits ${{ github.event.pull_request.base.sha }}..HEAD

--- a/.github/workflows/pythonlint.yaml
+++ b/.github/workflows/pythonlint.yaml
@@ -1,0 +1,51 @@
+name: Python linters
+
+on:
+  workflow_call:
+    inputs:
+      source_dirs:
+        description: "Stringified JSON object listing target source folders"
+        required: true
+        type: string
+      python_version:
+        description: "Python version"
+        required: false
+        type: string
+        default: "3.8"
+
+jobs:
+  pythonlint:
+    name: Lint Python code
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        folder: ${{fromJson(inputs.source_dirs)}}
+    defaults:
+      run:
+        working-directory: ${{ matrix.folder }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "true"
+      - name: Get repo root path
+        run: |
+          echo "GIT_ROOT=$(git rev-parse --show-toplevel)" >> $GITHUB_ENV
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Install tox
+        run: pip install tox
+      - name: Run black
+        run: tox -e black
+      - name: Run mypy
+        if: success() || failure()
+        run: tox -e mypy
+      - name: Run pylint
+        if: success() || failure()
+        run: tox -e pylint
+      - name: Run flake
+        if: success() || failure()
+        run: tox -e flake

--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ This repo contains [reusable workflows](https://docs.github.com/en/actions/using
 This repo contains the following workflows:
 
 - `trivy` - install [trivy](https://github.com/aquasecurity/trivy) and check vulnerabilities in docker images
+- `pythonlint` - install [tox](https://tox.wiki/en/latest/) and run python linter
+- `gitlint` - run gitlinter to check the commits in the pull request
+- `dockerlint` - run [hadolint](https://github.com/hadolint/hadolint) over the project's dockerfiles
+- `docker-build-push` - build docker images and push them to DO docker registry
+- `docker-add-version-and-latest-tags` - add `latest` and `github.event.release.tag_name` tags to docker images


### PR DESCRIPTION
## Motivation
We have a set of the repeating workflows (`pythinlint`, `gitlint`, `dockerlint`, `build and push docker images`, `add tags to a docker image`) to avoid copy-paste these workflows we need to move them to this repository and use them as reusable workflows.

## Solution
The following workflows have been added:
- `pythonlint` - install [tox](https://tox.wiki/en/latest/) and run python linter
- `gitlint` - run gitlinter to check the commits in the pull request
- `dockerlint` - run [hadolint](https://github.com/hadolint/hadolint) over the project's dockerfiles
- `docker-build-push` - build docker images and push them to DO docker registry
- `docker-add-version-and-latest-tags` - add `latest` and `github.event.release.tag_name` tags to docker images

## Checklist

<details open=true>
  <summary>PR checklist (self-check before review)</summary>

- [X] The branch name fits the `pr-<prefix>-<task-name>` pattern;
- [X] The PR has a meaningful name using the `<prefix>: <description>` pattern;
- [X] The PR is properly labeled depending on the change;
- [X] The PR is assigned to you;
- [X] If the PR is based on another PR, links to them are added to the PR header and the "has PR dependency" label is set;
- [X] Self-review. Review your code, commits, and the PR description;
- [X] Make sure that you updated the corresponding docs in the `docs/` directory;
- [X] Links to the updated docs are added to the PR header (if any);
- [X] CI successfully finished;

</details>
