### PR TITLE
github: workflows: add build context to docker-build-push workflow

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -63,6 +63,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           file: ${{ matrix.file }}
           build-args: ${{ matrix.build-args }}
+          context: ${{ matrix.context }}
           secrets: ${{ secrets.build_secrets }}
       - name: Move cache
         run: |


### PR DESCRIPTION
## Motivation
We use the `context` field from [build-push-action](https://github.com/docker/build-push-action) in some of our projects so we need to add this field to the `docker-build-push.yaml` workflow.

## Solution
The `context` field has been added to the `docker-build-push.yaml` workflow.

## Checklist

<details open=true>
  <summary>PR checklist (self-check before review)</summary>

- [X] The branch name fits the `pr-<prefix>-<task-name>` pattern;
- [X] The PR has a meaningful name using the `<prefix>: <description>` pattern;
- [X] The PR is properly labeled depending on the change;
- [X] The PR is assigned to you;
- [X] If the PR is based on another PR, links to them are added to the PR header and the "has PR dependency" label is set;
- [X] Self-review. Review your code, commits, and the PR description;
- [X] Make sure that you updated the corresponding docs in the `docs/` directory;
- [X] Links to the updated docs are added to the PR header (if any);
- [X] CI successfully finished;

</details>
