### PR TITLE
trivy: pass `.trivyignore` to `trivyignores`

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -29,6 +29,11 @@ jobs:
       - name: Pull docker image
         run: |
           docker pull ${{ matrix.image }}
+      - name: Git checkout
+        uses: actions/checkout@v3
+      - name: Get .trivyignore file or nothing
+        run: find .trivyignore 2> /dev/null || true
+        id: find_trivyignore
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
@@ -38,3 +43,4 @@ jobs:
           ignore-unfixed: true
           severity: "HIGH,CRITICAL"
           exit-code: "1"
+          trivyignores: ${{ steps.find_trivyignore.outputs.value }}


### PR DESCRIPTION
## Motivation

`.trivyignore` allows [filtering](https://aquasecurity.github.io/trivy/v0.30.1/docs/vulnerability/examples/filter/) specific vulnerabilities, which is relevant when we are waiting for a dependency to fix its issue.

## Solution

Set `trivyignores` to `.trivyignore`, this additionally requires fetching a repo where `.trivyignore` is stored and checking whether there is `.trivyignore` in the root, otherwise the action fails.

## Checklist

<details open=true>
  <summary>PR checklist (self-check before review)</summary>

- [x] The branch name fits the `pr-<prefix>-<task-name>` pattern;
- [x] The PR has a meaningful name using the `<prefix>: <description>` pattern;
- [x] The PR is properly labeled depending on the change;
- [x] The PR is assigned to you;
- [ ] If the PR is based on another PR, links to them are added to the PR header and the "has PR dependency" label is set;
- [x] Self-review. Review your code, commits, and the PR description;
- [ ] Make sure that you updated the corresponding docs in the `docs/` directory;
- [ ] Links to the updated docs are added to the PR header (if any);
- [x] CI successfully finished;

</details>
